### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,17 +6,17 @@
 #       Data types (KEYWORD1)        #
 ######################################
 
-Sensor KEYWORD1
-AnalogSensor KEYWORD1
-DigitalSensor KEYWORD1
-MapSensor KEYWORD1
-ConstrainSensor KEYWORD1
-AverageSensor KEYWORD1
+Sensor	KEYWORD1
+AnalogSensor	KEYWORD1
+DigitalSensor	KEYWORD1
+MapSensor	KEYWORD1
+ConstrainSensor	KEYWORD1
+AverageSensor	KEYWORD1
 
 ######################################
 #  Methods and Functions (KEYWORD2)  #
 ######################################
 
-read KEYWORD2
-isHigh KEYWORD2
-isLow KEYWORD2
+read	KEYWORD2
+isHigh	KEYWORD2
+isLow	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords